### PR TITLE
Use bundler build and define wasm plugins for worker, too

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,13 +1,11 @@
 <script lang="ts">
-  import init, * as Nimiq from "@nimiq/core/web";
+  import * as Nimiq from "@nimiq/core";
   import { onMount } from "svelte";
 
   let client: Nimiq.Client | null = null;
   let consensus: Nimiq.ConsensusState | null = null;
   let head: Nimiq.PlainBlock | null = null;
   onMount(async () => {
-    await init();
-
     const config = new Nimiq.ClientConfiguration();
     const client = await Nimiq.Client.create(config.build());
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,6 +9,12 @@ export default defineConfig({
 		wasm(), 
     topLevelAwait(), 
 	],
+	worker: {
+		plugins: [
+			wasm(),
+			topLevelAwait(), 
+		],
+	},
 	optimizeDeps: { 
     exclude: ['@nimiq/core'], 
   }, 


### PR DESCRIPTION
The `./web` version of @nimiq/core cannot be used with Vite (anymore?), since the import analyzer cannot find a `node` export definition for the `./web` path. That's because it doesn't exist. So the `./web` path can not (no longer?) be used with Vite.

This PR instead changes the used @nimiq/core version to the bundler build and fixes the resulting error of handling wasm in the web worker.